### PR TITLE
Adds fix for < IE10 

### DIFF
--- a/lib/bragi/transports/Console.js
+++ b/lib/bragi/transports/Console.js
@@ -11,8 +11,13 @@ var SYMBOLS = require('../symbols');
 // point been opened in that tab. However, even after console and console.log
 // exist, typeof console.log still evaluate to object, not function, so
 // methods like .apply will cause errors
-if ((typeof window.console !== 'function') || !window.console) {
-    window.console = function() {};
+if (window.console && window.console.log) {
+    if (typeof window.console.log !== 'function') {
+        window.console = function () {};
+    }
+} else {
+    window.console = {};
+    window.console.log = function () {};
 }
 
 // --------------------------------------


### PR DESCRIPTION
Adds a fix for < IE 10 where `console.log.apply` would cause errors because `typeof console.log` evaluated to `"object"` and not `"function"`. 
