### PR TITLE
Adds fix for < IE10

### DIFF
--- a/lib/bragi/transports/Console.js
+++ b/lib/bragi/transports/Console.js
@@ -13,7 +13,7 @@ var SYMBOLS = require('../symbols');
 // methods like .apply will cause errors
 if (window.console && window.console.log) {
     if (typeof window.console.log !== 'function') {
-        window.console = function () {};
+        window.console.log = function () {};
     }
 } else {
     window.console = {};


### PR DESCRIPTION
Adds a fix for < IE 10 where `console.log.apply` would cause errors because `typeof console.log` evaluated to `"object"` and not `"function"`.
